### PR TITLE
Add password login and register page

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,7 @@ import config from './config.json';
 import './library/styles/main.scss';
 
 import Login from './pages/account';
+import Register from './pages/account/register';
 import Manual from './pages/account/manual';
 import Home from './pages/home';
 import NotFound from './pages/errors/notFound';
@@ -21,8 +22,9 @@ const App = () => {
         <Routes>
           {/* Regular routes */}
           <Route path="/" element={<Login />} />
+          <Route path="/register" element={<Register />} />
           <Route path="/home" element={<Home />} />
-          <Route path="/manual" element={<Manual />} />          
+          <Route path="/manual" element={<Manual />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       )}

--- a/src/pages/account/register.js
+++ b/src/pages/account/register.js
@@ -4,8 +4,9 @@ import Layout from '../../layouts/primary';
 import './login.scss';
 import pageContent from './content.json';
 
-const Login = () => {
+const Register = () => {
   const navigate = useNavigate();
+  const [name, setName] = useState('');
   const [phoneNumber, setPhoneNumber] = useState('');
   const [password, setPassword] = useState('');
 
@@ -14,26 +15,28 @@ const Login = () => {
     if (token) navigate('/home');
   }, [navigate]);
 
-  const handleLogin = async (e) => {
+  const handleRegister = async (e) => {
     e.preventDefault();
 
     if (phoneNumber.length !== 10 || !/^\d{10}$/.test(phoneNumber)) {
       alert('Enter a valid 10-digit phone number.');
       return;
     }
-    if (!password) {
-      alert('Password cannot be empty.');
+
+    if (!name || !password) {
+      alert('All fields are required.');
       return;
     }
 
     try {
-      const response = await fetch('https://api-worknest.cainethings.com/login.php', {
+      const response = await fetch('https://api-worknest.cainethings.com/register.php', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
         credentials: 'include',
         body: JSON.stringify({
+          name: name,
           phone: phoneNumber,
           password: password,
         }),
@@ -42,24 +45,33 @@ const Login = () => {
       const result = await response.json();
 
       if (result.success) {
-        localStorage.setItem('isLoggedIn', true);
-        localStorage.setItem('phoneNumber', phoneNumber);
-        navigate('/home');
+        alert('Registration successful. Please log in.');
+        navigate('/');
       } else {
-        alert(result.message || 'Login failed');
+        alert(result.message || 'Registration failed');
       }
     } catch (error) {
       console.error('Server error:', error);
-      alert('Unable to login at the moment. Try again later.');
+      alert('Unable to register at the moment. Try again later.');
     }
   };
 
   return (
     <Layout pageContent={pageContent}>
       <section className='hero'>
-        <h1 className='section-title'>Login</h1>
-        <p className='instruction'>Enter your phone number and password to login.</p>
-        <form onSubmit={handleLogin}>
+        <h1 className='section-title'>Register</h1>
+        <p className='instruction'>Create a new account.</p>
+        <form onSubmit={handleRegister}>
+          <div className='custom-field'>
+            <p className='field-label'>Name</p>
+            <input
+              type='text'
+              name='name'
+              placeholder='Full Name'
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
           <div className='custom-field'>
             <p className='field-label'>Phone Number</p>
             <input
@@ -81,14 +93,14 @@ const Login = () => {
               onChange={(e) => setPassword(e.target.value)}
             />
           </div>
-          <button type='submit'>Login</button>
+          <button type='submit'>Register</button>
         </form>
         <p className='disclaimer'>
-          Don't have an account? <a href='/register'>Register</a>
+          Already have an account? <a href='/'>Login</a>
         </p>
       </section>
     </Layout>
   );
 };
 
-export default Login;
+export default Register;


### PR DESCRIPTION
## Summary
- replace OTP login with password-based login
- add new registration page
- wire registration route in React app

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854568de14483328bcc62e592e23585