### PR TITLE
Add local PHP API and setup instructions

### DIFF
--- a/php-api/.env.example
+++ b/php-api/.env.example
@@ -1,0 +1,5 @@
+DB_HOST=localhost
+DB_NAME=worknest
+DB_USER=root
+DB_PASS=secret
+ALLOW_LOCALHOST=true

--- a/php-api/.htaccess
+++ b/php-api/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine On
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteRule ^ index.php [QSA,L]

--- a/php-api/app/helpers.php
+++ b/php-api/app/helpers.php
@@ -1,0 +1,48 @@
+<?php
+function findPhoneInCsv($phone) {
+    $dataDir = __DIR__ . '/../data';
+    $results = [];
+    foreach (glob($dataDir . '/*.csv') as $file) {
+        if (($handle = fopen($file, 'r')) !== false) {
+            $header = fgetcsv($handle);
+            while (($row = fgetcsv($handle)) !== false) {
+                $record = array_combine($header, $row);
+                if ($record['phone_number'] === $phone || $record['phone'] === $phone) {
+                    $results[basename($file, '.csv')] = $record;
+                    break;
+                }
+            }
+            fclose($handle);
+        }
+    }
+    return $results;
+}
+
+function listMonthFiles() {
+    $dataDir = __DIR__ . '/../data';
+    $files = [];
+    foreach (glob($dataDir . '/*.csv') as $file) {
+        $files[] = basename($file);
+    }
+    sort($files);
+    return $files;
+}
+
+function getPayslipRecord($monthFile, $phone) {
+    $path = __DIR__ . '/../data/' . $monthFile;
+    if (!file_exists($path)) {
+        return null;
+    }
+    if (($handle = fopen($path, 'r')) !== false) {
+        $header = fgetcsv($handle);
+        while (($row = fgetcsv($handle)) !== false) {
+            $record = array_combine($header, $row);
+            if ($record['phone_number'] === $phone || $record['phone'] === $phone) {
+                fclose($handle);
+                return $record;
+            }
+        }
+        fclose($handle);
+    }
+    return null;
+}

--- a/php-api/config/database.php
+++ b/php-api/config/database.php
@@ -1,0 +1,14 @@
+<?php
+function getPDO() {
+    $envPath = __DIR__ . '/../.env';
+    if (!file_exists($envPath)) {
+        throw new Exception('Missing .env file');
+    }
+    $env = parse_ini_file($envPath);
+    $dsn = "mysql:host={$env['DB_HOST']};dbname={$env['DB_NAME']};charset=utf8mb4";
+    $options = [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ];
+    return new PDO($dsn, $env['DB_USER'], $env['DB_PASS'], $options);
+}

--- a/php-api/data/April-25.csv
+++ b/php-api/data/April-25.csv
@@ -1,0 +1,2 @@
+phone_number,employee_id,FULL NAME,Designation,ID,Basic Rate,Days Paid,OT Hours,F/D,D.O.J,UAN,Bank,A/c No,IFSC,Wages Earned,EPF,Mess,HRA,Advance,S Allowance,Bonus @ 8.33%,Area Allowance,Washing Allowance,Performance Allowance,GROSS AMT,Total Deduction,Net Pay Credited to Bank A/c
+1234567890,EID001,John Doe,Engineer,EMP001,50000,30,0,D,45000,1001001010,XYZ Bank,123456789012,IFSC0001,50000,5000,1000,3000,0,2000,5000,1000,500,2000,58000,6000,52000

--- a/php-api/index.php
+++ b/php-api/index.php
@@ -1,0 +1,124 @@
+<?php
+require_once __DIR__ . '/config/database.php';
+require_once __DIR__ . '/app/helpers.php';
+
+session_start();
+header('Content-Type: application/json');
+
+$pdo = null;
+try {
+    $pdo = getPDO();
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Database connection failed']);
+    exit;
+}
+
+$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+$method = $_SERVER['REQUEST_METHOD'];
+
+switch ($path) {
+    case '/users':
+        if ($method === 'POST') {
+            $stmt = $pdo->query('SELECT id, phone_number, employee_id FROM users');
+            echo json_encode($stmt->fetchAll());
+            exit;
+        }
+        break;
+    case '/register':
+        if ($method === 'POST') {
+            $data = json_decode(file_get_contents('php://input'), true);
+            $phone = $data['phone_number'] ?? $data['phone'] ?? '';
+            $eid = $data['employee_id'] ?? '';
+            $pass = $data['password'] ?? '';
+            if (!$phone || !$eid || !$pass) {
+                http_response_code(400);
+                echo json_encode(['success'=>false,'message'=>'Missing fields']);
+                exit;
+            }
+            $records = findPhoneInCsv($phone);
+            if (empty($records)) {
+                http_response_code(404);
+                echo json_encode(['success'=>false,'message'=>'Phone number not found in records']);
+                exit;
+            }
+            $hash = password_hash($pass, PASSWORD_DEFAULT);
+            $stmt = $pdo->prepare('INSERT INTO users(phone_number, employee_id, password_hash) VALUES(?,?,?)');
+            try {
+                $stmt->execute([$phone, $eid, $hash]);
+                echo json_encode(['message'=>'User registered']);
+            } catch (PDOException $e) {
+                http_response_code(400);
+                echo json_encode(['success'=>false,'message'=>'User already exists']);
+            }
+            exit;
+        }
+        break;
+    case '/login':
+        if ($method === 'POST') {
+            $data = json_decode(file_get_contents('php://input'), true);
+            $phone = $data['phone_number'] ?? $data['phone'] ?? '';
+            $pass = $data['password'] ?? '';
+            if (!$phone || !$pass) {
+                http_response_code(400);
+                echo json_encode(['success'=>false,'message'=>'Missing credentials']);
+                exit;
+            }
+            $stmt = $pdo->prepare('SELECT id, phone_number, employee_id, password_hash FROM users WHERE phone_number=?');
+            $stmt->execute([$phone]);
+            $user = $stmt->fetch();
+            if (!$user || !password_verify($pass, $user['password_hash'])) {
+                http_response_code(401);
+                echo json_encode(['success'=>false,'message'=>'Invalid credentials']);
+                exit;
+            }
+            $_SESSION['user_id'] = $user['id'];
+            echo json_encode(['success'=>true,'message'=>'Login successful','user'=>[
+                'id'=>$user['id'],
+                'phone_number'=>$user['phone_number'],
+                'employee_id'=>$user['employee_id']
+            ]]);
+            exit;
+        }
+        break;
+    case '/records':
+        if ($method === 'POST') {
+            $data = json_decode(file_get_contents('php://input'), true);
+            $phone = $data['phone_number'] ?? $data['phone'] ?? '';
+            $records = findPhoneInCsv($phone);
+            if (empty($records)) {
+                http_response_code(404);
+                echo json_encode(['success'=>false,'message'=>'No records found']);
+            } else {
+                echo json_encode($records);
+            }
+            exit;
+        }
+        break;
+    case '/getAvailableMonths.php':
+    case '/getAvailableMonths':
+        if ($method === 'POST') {
+            $files = listMonthFiles();
+            echo json_encode(['success'=>true,'files'=>$files]);
+            exit;
+        }
+        break;
+    case '/getPayslip.php':
+    case '/getPayslip':
+        if ($method === 'POST') {
+            $data = json_decode(file_get_contents('php://input'), true);
+            $month = $data['month'] ?? '';
+            $phone = $data['phone'] ?? $data['phone_number'] ?? '';
+            $record = getPayslipRecord($month.'.csv', $phone);
+            if (!$record) {
+                http_response_code(404);
+                echo json_encode(['success'=>false,'message'=>'Payslip not found']);
+            } else {
+                echo json_encode(['success'=>true,'data'=>$record]);
+            }
+            exit;
+        }
+        break;
+}
+http_response_code(404);
+echo json_encode(['success'=>false,'message'=>'Endpoint not found']);

--- a/php-api/users.sql
+++ b/php-api/users.sql
@@ -1,0 +1,6 @@
+CREATE TABLE users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  phone_number VARCHAR(20) NOT NULL UNIQUE,
+  employee_id VARCHAR(50) NOT NULL,
+  password_hash VARCHAR(255) NOT NULL
+);

--- a/readme.md
+++ b/readme.md
@@ -65,3 +65,30 @@ All API calls are `POST` requests with JSON bodies. CORS is allowed only from th
 ---
 
 This project is maintained alongside the WorkNest API repository. Contributions are welcome.
+
+## PHP API (Local)
+
+A minimal PHP backend is included in the `php-api/` directory. It uses MySQL and monthly CSV files.
+
+### Setup
+
+1. Create a MySQL database and run `php-api/users.sql` to create the `users` table.
+2. Copy `php-api/.env.example` to `php-api/.env` and update the credentials.
+3. Place monthly payroll CSV files inside `php-api/data/` (sample `April-25.csv` is provided).
+4. Start the API using PHP's built-in server:
+   ```bash
+   php -S localhost:8888 index.php -t php-api
+   ```
+
+### Endpoints
+
+- `POST /register` – register a user
+- `POST /login` – authenticate and start a session
+- `POST /getAvailableMonths` – list available CSV files
+- `POST /getPayslip` – fetch a payslip by month and phone number
+
+### Running Together
+
+For local development set `environment` to `local` in `src/config.json` so the React app calls `http://localhost:8888`.
+
+Start the API and then in another terminal run `npm start` to launch the React app. Register or log in with a phone number found in one of the CSV files. After logging in, the home page shows a dropdown of months and allows downloading a PDF payslip.

--- a/src/config.json
+++ b/src/config.json
@@ -1,5 +1,5 @@
 {
-  "environment": "production",
+  "environment": "local",
   "apiBaseUrls": {
     "production": "https://api-worknest.cainethings.com",
     "staging": "https://stage-api-worknest.cainethings.com",


### PR DESCRIPTION
## Summary
- add `php-api` folder with minimal PHP backend
- update config to use local API during development
- document how to run the PHP API and React app

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68578bcf7ce48332a2629528e12bb730