### PR TITLE
Update records functionality

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,8 +57,7 @@ The WorkNest API provides the following PHP endpoints:
 
 - `register.php` – create a user
 - `login.php` – authenticate a user
-- `getAvailableMonths.php` – list months with payroll data
-- `getPayslip.php` – retrieve a single payslip record
+- `records.php` – return available months along with their payslip data
 
 All API calls are `POST` requests with JSON bodies. CORS is allowed only from the staging and production front-end domains.
 


### PR DESCRIPTION
## Summary
- refactor home page to fetch all records with `/records`
- update PDF download to use fetched records
- document the new `records.php` API endpoint

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6857c9b9e8a88332a254f0b5d10a54c0