### PR TITLE
Replace password with PIN

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ WorkNest is a simple payroll viewer built with React. It allows employees to reg
 
 ## Features
 
-- **User Registration** – create a login using phone number, employee ID and password.
+- **User Registration** – create a login using phone number, employee ID and a 4-digit PIN (with confirmation).
 - **Login** – authenticate via `/login.php` and store a session.
 - **Payslip Viewer** – list available months and fetch payslip data.
 - **PDF Download** – convert the payslip table to a PDF using `html2pdf.js`.

--- a/src/pages/account/index.js
+++ b/src/pages/account/index.js
@@ -8,7 +8,7 @@ import { getApiBaseUrl } from '../../api';
 const Login = () => {
   const navigate = useNavigate();
   const [phoneNumber, setPhoneNumber] = useState('');
-  const [password, setPassword] = useState('');
+  const [pin, setPin] = useState('');
 
   useEffect(() => {
     const token = localStorage.getItem('isLoggedIn');
@@ -22,8 +22,8 @@ const Login = () => {
       alert('Enter a valid 10-digit phone number.');
       return;
     }
-    if (!password) {
-      alert('Password cannot be empty.');
+    if (pin.length !== 4 || !/^\d{4}$/.test(pin)) {
+      alert('PIN must be exactly 4 digits.');
       return;
     }
 
@@ -36,7 +36,7 @@ const Login = () => {
         credentials: 'include',
         body: JSON.stringify({
           phone: phoneNumber,
-          password: password,
+          pin: pin,
         }),
       });
 
@@ -63,7 +63,7 @@ const Login = () => {
     <Layout pageContent={pageContent}>
       <section className='hero'>
         <h1 className='section-title'>Login</h1>
-        <p className='instruction'>Enter your phone number and password to login.</p>
+        <p className='instruction'>Enter your phone number and 4‑digit PIN to login.</p>
         <form onSubmit={handleLogin}>
           <div className='custom-field'>
             <p className='field-label'>Phone Number</p>
@@ -77,13 +77,14 @@ const Login = () => {
             />
           </div>
           <div className='custom-field'>
-            <p className='field-label'>Password</p>
+            <p className='field-label'>PIN</p>
             <input
               type='password'
-              name='password'
-              placeholder='Enter password'
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              name='pin'
+              placeholder='1234'
+              maxLength='4'
+              value={pin}
+              onChange={(e) => setPin(e.target.value.replace(/\D/, ''))}
             />
           </div>
           <button type='submit'>Login</button>

--- a/src/pages/account/manual.js
+++ b/src/pages/account/manual.js
@@ -4,12 +4,12 @@ import Layout from '../../layouts/primary';
 import './login.scss';
 import pageContent from './content.json';
 
-const SHA256_HASH = '8cceec2c501bb9f97584fa5b9f5b3bd5f7aef4985dade3827736f00d7c448b90'; // hash for "iamadmin123"
+const SHA256_HASH = '03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4'; // hash for "1234"
 
 const ManualLogin = () => {
   const navigate = useNavigate();
   const [phoneNumber, setPhoneNumber] = useState('');
-  const [password, setPassword] = useState('');
+  const [pin, setPin] = useState('');
 
   useEffect(() => {
     const token = localStorage.getItem('isLoggedIn');
@@ -33,10 +33,10 @@ const ManualLogin = () => {
       return;
     }
 
-    const hashedInput = await hashPassword(password);
+    const hashedInput = await hashPassword(pin);
 
     if (hashedInput !== SHA256_HASH) {
-      alert('Incorrect password. Access denied.');
+      alert('Incorrect PIN. Access denied.');
       return;
     }
 
@@ -52,7 +52,7 @@ const ManualLogin = () => {
     <Layout pageContent={pageContent}>
       <section className='hero'>
         <h1 className='section-title'>Manual Login (Testing)</h1>
-        <p className='instruction'>Enter a phone number and admin password to login manually.</p>
+        <p className='instruction'>Enter a phone number and admin PIN to login manually.</p>
 
         <form onSubmit={handleManualLogin}>
           <div className='custom-field'>
@@ -68,13 +68,14 @@ const ManualLogin = () => {
           </div>
 
           <div className='custom-field'>
-            <p className='field-label'>Admin Password</p>
+            <p className='field-label'>Admin PIN</p>
             <input
               type='password'
-              name='password'
-              placeholder='Enter password'
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              name='pin'
+              placeholder='1234'
+              maxLength='4'
+              value={pin}
+              onChange={(e) => setPin(e.target.value.replace(/\D/, ''))}
             />
           </div>
 
@@ -82,7 +83,7 @@ const ManualLogin = () => {
         </form>
 
         <p className='disclaimer warning'>
-          ⚠️ This manual login is protected by a static password. For testing use only.
+          ⚠️ This manual login is protected by a static PIN. For testing use only.
         </p>
       </section>
     </Layout>

--- a/src/pages/account/register.js
+++ b/src/pages/account/register.js
@@ -9,7 +9,8 @@ const Register = () => {
   const navigate = useNavigate();
   const [employeeId, setEmployeeId] = useState('');
   const [phoneNumber, setPhoneNumber] = useState('');
-  const [password, setPassword] = useState('');
+  const [pin, setPin] = useState('');
+  const [confirmPin, setConfirmPin] = useState('');
 
   useEffect(() => {
     const token = localStorage.getItem('isLoggedIn');
@@ -24,8 +25,15 @@ const Register = () => {
       return;
     }
 
-    if (!employeeId || !password) {
-      alert('All fields are required.');
+    if (
+      !employeeId ||
+      pin.length !== 4 ||
+      !/^\d{4}$/.test(pin) ||
+      confirmPin !== pin
+    ) {
+      alert(
+        'All fields are required, PIN must be exactly 4 digits and both PINs must match.'
+      );
       return;
     }
 
@@ -39,7 +47,7 @@ const Register = () => {
         body: JSON.stringify({
           employee_id: employeeId,
           phone: phoneNumber,
-          password: password,
+          pin: pin,
         }),
       });
 
@@ -89,13 +97,25 @@ const Register = () => {
             />
           </div>
           <div className='custom-field'>
-            <p className='field-label'>Password</p>
+            <p className='field-label'>PIN</p>
             <input
               type='password'
-              name='password'
-              placeholder='Enter password'
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              name='pin'
+              placeholder='1234'
+              maxLength='4'
+              value={pin}
+              onChange={(e) => setPin(e.target.value.replace(/\D/, ''))}
+            />
+          </div>
+          <div className='custom-field'>
+            <p className='field-label'>Confirm PIN</p>
+            <input
+              type='password'
+              name='confirmPin'
+              placeholder='1234'
+              maxLength='4'
+              value={confirmPin}
+              onChange={(e) => setConfirmPin(e.target.value.replace(/\D/, ''))}
             />
           </div>
           <button type='submit'>Register</button>


### PR DESCRIPTION
## Summary
- switch login and registration to use a 4-digit PIN
- update manual admin login to accept a 4-digit PIN
- document PIN usage in the README
- add confirm PIN field on registration form

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859108755ec833299bf0f343646513f