### PR TITLE
Improve placeholder text and visibility

### DIFF
--- a/src/library/styles/typography.scss
+++ b/src/library/styles/typography.scss
@@ -12,6 +12,10 @@ $font-family-content-paragraph: "Source Serif 4", serif;
     font-size: 16px;
 }
 
+// Style placeholders globally with 10% visibility
+input::placeholder {
+    color: rgba(0, 0, 0, 0.1);
+}
 
 .content-heading {
     font-family: $font-family-content-heading;

--- a/src/pages/account/index.js
+++ b/src/pages/account/index.js
@@ -70,7 +70,7 @@ const Login = () => {
             <input
               type='tel'
               name='phoneNumber'
-              placeholder='9876543210'
+              placeholder='Enter phone number'
               maxLength='10'
               value={phoneNumber}
               onChange={(e) => setPhoneNumber(e.target.value.replace(/\D/, ''))}
@@ -81,7 +81,7 @@ const Login = () => {
             <input
               type='password'
               name='pin'
-              placeholder='1234'
+              placeholder='Enter 4-digit PIN'
               maxLength='4'
               value={pin}
               onChange={(e) => setPin(e.target.value.replace(/\D/, ''))}

--- a/src/pages/account/manual.js
+++ b/src/pages/account/manual.js
@@ -60,7 +60,7 @@ const ManualLogin = () => {
             <input
               type='tel'
               name='phoneNumber'
-              placeholder='9876543210'
+              placeholder='Enter phone number'
               maxLength='10'
               value={phoneNumber}
               onChange={(e) => setPhoneNumber(e.target.value.replace(/\D/, ''))}
@@ -72,7 +72,7 @@ const ManualLogin = () => {
             <input
               type='password'
               name='pin'
-              placeholder='1234'
+              placeholder='Enter admin PIN'
               maxLength='4'
               value={pin}
               onChange={(e) => setPin(e.target.value.replace(/\D/, ''))}

--- a/src/pages/account/register.js
+++ b/src/pages/account/register.js
@@ -80,7 +80,7 @@ const Register = () => {
             <input
               type='text'
               name='employeeId'
-              placeholder='12345'
+              placeholder='Enter employee ID'
               value={employeeId}
               onChange={(e) => setEmployeeId(e.target.value)}
             />
@@ -90,7 +90,7 @@ const Register = () => {
             <input
               type='tel'
               name='phoneNumber'
-              placeholder='9876543210'
+              placeholder='Enter phone number'
               maxLength='10'
               value={phoneNumber}
               onChange={(e) => setPhoneNumber(e.target.value.replace(/\D/, ''))}
@@ -101,7 +101,7 @@ const Register = () => {
             <input
               type='password'
               name='pin'
-              placeholder='1234'
+              placeholder='Create 4-digit PIN'
               maxLength='4'
               value={pin}
               onChange={(e) => setPin(e.target.value.replace(/\D/, ''))}
@@ -112,7 +112,7 @@ const Register = () => {
             <input
               type='password'
               name='confirmPin'
-              placeholder='1234'
+              placeholder='Repeat PIN'
               maxLength='4'
               value={confirmPin}
               onChange={(e) => setConfirmPin(e.target.value.replace(/\D/, ''))}


### PR DESCRIPTION
## Summary
- style all input placeholders with 10% opacity
- use instructional placeholder text on login, register and manual forms

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68591e270b408332ba65d1ee10c3d0a2