### PR TITLE
Enable numeric keypad for phone and pin fields

### DIFF
--- a/src/pages/account/index.js
+++ b/src/pages/account/index.js
@@ -72,6 +72,7 @@ const Login = () => {
               name='phoneNumber'
               placeholder='Enter phone number'
               maxLength='10'
+              inputMode='numeric'
               value={phoneNumber}
               onChange={(e) => setPhoneNumber(e.target.value.replace(/\D/, ''))}
             />
@@ -83,6 +84,7 @@ const Login = () => {
               name='pin'
               placeholder='Enter 4-digit PIN'
               maxLength='4'
+              inputMode='numeric'
               value={pin}
               onChange={(e) => setPin(e.target.value.replace(/\D/, ''))}
             />

--- a/src/pages/account/manual.js
+++ b/src/pages/account/manual.js
@@ -62,6 +62,7 @@ const ManualLogin = () => {
               name='phoneNumber'
               placeholder='Enter phone number'
               maxLength='10'
+              inputMode='numeric'
               value={phoneNumber}
               onChange={(e) => setPhoneNumber(e.target.value.replace(/\D/, ''))}
             />
@@ -74,6 +75,7 @@ const ManualLogin = () => {
               name='pin'
               placeholder='Enter admin PIN'
               maxLength='4'
+              inputMode='numeric'
               value={pin}
               onChange={(e) => setPin(e.target.value.replace(/\D/, ''))}
             />

--- a/src/pages/account/register.js
+++ b/src/pages/account/register.js
@@ -92,6 +92,7 @@ const Register = () => {
               name='phoneNumber'
               placeholder='Enter phone number'
               maxLength='10'
+              inputMode='numeric'
               value={phoneNumber}
               onChange={(e) => setPhoneNumber(e.target.value.replace(/\D/, ''))}
             />
@@ -103,6 +104,7 @@ const Register = () => {
               name='pin'
               placeholder='Create 4-digit PIN'
               maxLength='4'
+              inputMode='numeric'
               value={pin}
               onChange={(e) => setPin(e.target.value.replace(/\D/, ''))}
             />
@@ -114,6 +116,7 @@ const Register = () => {
               name='confirmPin'
               placeholder='Repeat PIN'
               maxLength='4'
+              inputMode='numeric'
               value={confirmPin}
               onChange={(e) => setConfirmPin(e.target.value.replace(/\D/, ''))}
             />


### PR DESCRIPTION
## Summary
- enable numeric keypad in login, registration, and manual login pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68592248424c833289a7accaf76944ba